### PR TITLE
Support for "useMojang" = false in config file.

### DIFF
--- a/src/main/java/lain/mods/skins/OfflineSkins.java
+++ b/src/main/java/lain/mods/skins/OfflineSkins.java
@@ -133,17 +133,21 @@ public class OfflineSkins
         {
             Configuration config = new Configuration(event.getSuggestedConfigurationFile());
             boolean useCrafatar = config.get(Configuration.CATEGORY_CLIENT, "useCrafatar", true).getBoolean(true);
+            boolean useMojang = config.get(Configuration.CATEGORY_CLIENT, "useMojang", true).getBoolean(true);
             if (config.hasChanged())
                 config.save();
 
             skinService = SkinProviderAPI.createService();
             capeService = SkinProviderAPI.createService();
 
-            skinService.register(new MojangCachedSkinProvider());
+            if (useMojang)            	
+                skinService.register(new MojangCachedSkinProvider());
             skinService.register(new UserManagedSkinProvider());
             if (useCrafatar)
                 skinService.register(new CrafatarCachedSkinProvider());
-            capeService.register(new MojangCachedCapeProvider());
+            
+            if (useMojang)
+                capeService.register(new MojangCachedCapeProvider());
             capeService.register(new UserManagedCapeProvider());
             if (useCrafatar)
                 capeService.register(new CrafatarCachedCapeProvider());


### PR DESCRIPTION
I saw another fork that allowed to change priority of skin sources.  But this one is simpler to just allow disabling of Mojang skin server if you truly want offline skins only.  Please consider including something like this in a future release, thanks!