### PR TITLE
Update fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,7 +24,7 @@
     "OfflineSkins-mixins.json"
   ],
 
-  "requires": {
+  "depends": {
     "fabricloader": ">=0.7.2",
     "fabric": "*"
   }


### PR DESCRIPTION
Launcher throws [main/WARN]: Mod `offlineskins` (1.15.2-v1-fabric) uses 'requires' key in fabric.mod.json, which is not supported - use 'depends' so I corrected line 27